### PR TITLE
structured-logging: enable KobjSlice usage and warn Kobjs usage

### DIFF
--- a/logcheck/README.md
+++ b/logcheck/README.md
@@ -80,3 +80,12 @@ disabled for the file.
 be used.  The corresponding helper calls from `k8s.io/klogr` should be used
 instead. This is relevant when support contextual logging is disabled at
 runtime in klog.
+
+## verbosity-zero (enabled by default)
+
+This check flags all invocation of `klog.V(0)` or any of it's equivalent as errors
+
+## deprecations (enabled by default)
+
+This checks detects the usage of deprecated `klog` helper functions such as `KObjs` and suggests
+a suitable alternative to replace them with.

--- a/logcheck/testdata/src/k8s.io/klog/v2/klog.go
+++ b/logcheck/testdata/src/k8s.io/klog/v2/klog.go
@@ -221,6 +221,11 @@ func KObjs(obj interface{}) interface{} {
 	return nil
 }
 
+// KObjSlice emulates klog.KObjSlice
+func KObjSlice(obj interface{}) interface{} {
+	return nil
+}
+
 func KRef(namespace, name string) interface{} {
 	return nil
 }

--- a/logcheck/testdata/src/onlyAllowContextual/onlyAllowContextual.go
+++ b/logcheck/testdata/src/onlyAllowContextual/onlyAllowContextual.go
@@ -29,4 +29,7 @@ func doNotAlllowKlog() {
 	klog.InfoS("test log")       // want `function "InfoS" should not be used, convert to contextual logging`
 	klog.ErrorS(nil, "test log") // want `function "ErrorS" should not be used, convert to contextual logging`
 	klog.V(1).Infof("test log")  // want `function "V" should not be used, convert to contextual logging` `function "Infof" should not be used, convert to contextual logging`
+
+	klog.KObjs(nil)                                // want `Detected usage of deprecated helper "KObjs". Please switch to "KObjSlice" instead.`
+	klog.InfoS("test log", "key", klog.KObjs(nil)) // want `function "InfoS" should not be used, convert to contextual logging` `Detected usage of deprecated helper "KObjs". Please switch to "KObjSlice" instead.`
 }

--- a/logcheck/testdata/src/onlyAllowContextual/whitelistedKlog.go
+++ b/logcheck/testdata/src/onlyAllowContextual/whitelistedKlog.go
@@ -27,7 +27,7 @@ import (
 
 func allowKlog() {
 	klog.KObj(nil)
-	klog.KObjs(nil)
+	klog.KObjSlice(nil)
 	klog.KRef("", "")
 	klog.FromContext(nil)
 	klog.TODO()


### PR DESCRIPTION
This pull request enables detection and warning on now deprecated `KObjs`.  It is suggested to use the `KObjSlice` instead of using `Kobjs` for better logging performance Since https://github.com/kubernetes/kubernetes/pull/110724 is now merged, We can reap the benefits of the change that went into the `klog` via https://github.com/kubernetes/klog/pull/322


Fixes Part of https://github.com/kubernetes/kubernetes/issues/110737