### PR TITLE
add klog.v(0) and logger.v(0) check

### DIFF
--- a/logcheck/main_test.go
+++ b/logcheck/main_test.go
@@ -103,6 +103,21 @@ func TestAnalyzer(t *testing.T) {
 			},
 			testPackage: "helpers",
 		},
+		{
+			name: "Do not allow Verbosity Zero logs",
+			enabled: map[string]string{
+				"structured": "false",
+			},
+			testPackage: "doNotAllowVerbosityZeroLogs",
+		},
+		{
+			name: "Allow Verbosity Zero logs",
+			enabled: map[string]string{
+				"structured":     "false",
+				"verbosity-zero": "false",
+			},
+			testPackage: "allowVerbosityZeroLogs",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/logcheck/testdata/src/allowVerbosityZeroLogs/allowVerbosityZeroLogs.go
+++ b/logcheck/testdata/src/allowVerbosityZeroLogs/allowVerbosityZeroLogs.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This fake package is created as golang.org/x/tools/go/analysis/analysistest
+// expects it to be here for loading. This package is used to test allow-unstructured
+// flag which suppresses errors when unstructured logging is used.
+// This is a test file for unstructured logging static check tool unit tests.
+
+package Verbosity
+
+import (
+	"github.com/go-logr/logr"
+	klog "k8s.io/klog/v2"
+)
+
+const (
+	zeroConst = 0
+	oneConst  = 1
+)
+
+var (
+	zeroVar   klog.Level = 0
+	oneVar    klog.Level = 1
+	l, logger logr.Logger
+)
+
+func verbosityLogging() {
+	klog.V(0).Info("test log")
+	klog.V(0).Infof("test log")
+	klog.V(0).Infoln("test log")
+	klog.V(0).InfoS("I'm logging at level 0.")
+	klog.V(zeroConst).InfoS("I'm logging at level 0.")
+	klog.V(zeroVar).InfoS("I'm logging at level 0.")
+	klog.V(1).Info("test log")
+	klog.V(1).Infof("test log")
+	klog.V(1).Infoln("test log")
+	klog.V(1).InfoS("I'm logging at level 1.")
+	klog.V(oneConst).InfoS("I'm logging at level 1.")
+	klog.V(oneVar).InfoS("I'm logging at level 1.")
+	klog.Info("test log")
+	klog.Infof("test log")
+	klog.Infoln("test log")
+	klog.InfoS("I'm logging at level 0.")
+
+	logger.Info("hello", "1", "2")
+	logger.Error(nil, "hello", "1", "2")
+	logger.WithValues("1", "2")
+
+	logger.V(0).Info("hello", "1", "2")
+	logger.V(0).Error(nil, "hello", "1", "2")
+	logger.V(0).WithValues("1", "2")
+
+	logger.V(1).Info("hello", "1", "2")
+	logger.V(1).Error(nil, "hello", "1", "2")
+	logger.V(1).WithValues("1", "2")
+}

--- a/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/doNotAllowVerbosityZeroLogs.go
+++ b/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/doNotAllowVerbosityZeroLogs.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This fake package is created as golang.org/x/tools/go/analysis/analysistest
+// expects it to be here for loading. This package is used to test allow-unstructured
+// flag which suppresses errors when unstructured logging is used.
+// This is a test file for unstructured logging static check tool unit tests.
+
+package Verbosity
+
+import (
+	"github.com/go-logr/logr"
+	klog "k8s.io/klog/v2"
+)
+
+const (
+	zeroConst = 0
+	oneConst  = 1
+)
+
+var (
+	zeroVar   klog.Level = 0
+	oneVar    klog.Level = 1
+	l, logger logr.Logger
+)
+
+func verbosityLogging() {
+	klog.V(0).Info("test log")                         // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	klog.V(0).Infof("test log")                        // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	klog.V(0).Infoln("test log")                       // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	klog.V(0).InfoS("I'm logging at level 0.")         // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	klog.V(zeroConst).InfoS("I'm logging at level 0.") // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	klog.V(zeroVar).InfoS("I'm logging at level 0.")
+	klog.V(1).Info("test log")
+	klog.V(1).Infof("test log")
+	klog.V(1).Infoln("test log")
+	klog.V(1).InfoS("I'm logging at level 1.")
+	klog.V(oneConst).InfoS("I'm logging at level 1.")
+	klog.V(oneVar).InfoS("I'm logging at level 1.")
+	klog.Info("test log")
+	klog.Infof("test log")
+	klog.Infoln("test log")
+	klog.InfoS("I'm logging at level 0.")
+
+	logger.Info("hello", "1", "2")
+	logger.Error(nil, "hello", "1", "2")
+	logger.WithValues("1", "2")
+
+	logger.V(0).Info("hello", "1", "2")       // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	logger.V(0).Error(nil, "hello", "1", "2") // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+	logger.V(0).WithValues("1", "2")          // want `Logging with V\(0\) is semantically equivalent to the same expression without it and just causes unnecessary overhead. It should get removed.`
+
+	logger.V(1).Info("hello", "1", "2")
+	logger.V(1).Error(nil, "hello", "1", "2")
+	logger.V(1).WithValues("1", "2")
+}


### PR DESCRIPTION
as mentioned in https://github.com/kubernetes-sigs/logtools/issues/2
Calling `V` with zero as parameter just causes additional overhead.
 we want a way to enforce that this code pattern doesn't get added back in some future PR