### PR TITLE
fix VerbosityZero check panic

### DIFF
--- a/logcheck/pkg/logcheck.go
+++ b/logcheck/pkg/logcheck.go
@@ -537,11 +537,15 @@ func isVerbosityZero(expr ast.Expr) bool {
 		return false
 	}
 
-	if lit, ok := subCallExpr.Args[0].(*ast.BasicLit); ok && lit.Value == "0" {
-		return true
+	if lit, ok := subCallExpr.Args[0].(*ast.BasicLit); ok {
+		if lit.Value == "0" {
+			return true
+		}
+		return false
 	}
 
-	if id, ok := subCallExpr.Args[0].(*ast.Ident); ok && id.Obj.Kind == 2 {
+	// When Constants of value is defined in different files, the id.Obj will be nil, we should filter this condition.
+	if id, ok := subCallExpr.Args[0].(*ast.Ident); ok && id.Obj != nil && id.Obj.Kind == 2 {
 		v, ok := id.Obj.Decl.(*ast.ValueSpec)
 		if !ok || len(v.Values) != 1 {
 			return false

--- a/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/constants.go
+++ b/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This fake package is created as golang.org/x/tools/go/analysis/analysistest
+// expects it to be here for loading. This package is used to test allow-unstructured
+// flag which suppresses errors when unstructured logging is used.
+// This is a test file for unstructured logging static check tool unit tests.
+
+package Verbosity
+
+const (
+	LogLevel = 4
+)

--- a/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/doNotAllowVerbosityZeroLogs.go
+++ b/logcheck/testdata/src/doNotAllowVerbosityZeroLogs/doNotAllowVerbosityZeroLogs.go
@@ -47,6 +47,7 @@ func verbosityLogging() {
 	klog.V(1).Info("test log")
 	klog.V(1).Infof("test log")
 	klog.V(1).Infoln("test log")
+	klog.V(LogLevel).InfoS("I'm logging at level 4.")
 	klog.V(1).InfoS("I'm logging at level 1.")
 	klog.V(oneConst).InfoS("I'm logging at level 1.")
 	klog.V(oneVar).InfoS("I'm logging at level 1.")


### PR DESCRIPTION
try to fix https://github.com/kubernetes-sigs/logtools/pull/4#discussion_r958364030

When Constants of value is defined in different files, there will be cases where it cannot be parsed directly.
it will trigger panic