### PR TITLE
Allow klog.InitFlags when checking contextual

### DIFF
--- a/logcheck/pkg/logcheck.go
+++ b/logcheck/pkg/logcheck.go
@@ -371,6 +371,7 @@ func isContextualCall(fName string) bool {
 		"FlushAndExit",
 		"FlushLogger",
 		"FromContext",
+		"InitFlags",
 		"KObj",
 		"KObjs",
 		"KObjSlice",


### PR DESCRIPTION
This PR fixes an oversight in the allow-list for checking for contextual logging.