### PR TITLE
check for interface inheritance

### DIFF
--- a/logcheck/main_test.go
+++ b/logcheck/main_test.go
@@ -143,6 +143,13 @@ func TestAnalyzer(t *testing.T) {
 			},
 			testPackage: "allowBadkeysLogs",
 		},
+		{
+			name: "Detect incomplete fmt.Stringer",
+			enabled: map[string]string{
+				"value": "true",
+			},
+			testPackage: "stringer",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/logcheck/pkg/logcheck.go
+++ b/logcheck/pkg/logcheck.go
@@ -39,6 +39,7 @@ const (
 	withHelpersCheck   = "with-helpers"
 	verbosityZeroCheck = "verbosity-zero"
 	keyCheck           = "key"
+	valueCheck         = "value"
 	deprecationsCheck  = "deprecations"
 )
 
@@ -63,6 +64,7 @@ func Analyser() *analysis.Analyzer {
 			withHelpersCheck:   new(bool),
 			verbosityZeroCheck: new(bool),
 			keyCheck:           new(bool),
+			valueCheck:         new(bool),
 			deprecationsCheck:  new(bool),
 		},
 	}
@@ -79,6 +81,7 @@ klog methods (Info, Infof, Error, Errorf, Warningf, etc).`)
 	logcheckFlags.BoolVar(c.enabled[withHelpersCheck], prefix+withHelpersCheck, false, `When true, logcheck will warn about direct calls to WithName, WithValues and NewContext.`)
 	logcheckFlags.BoolVar(c.enabled[verbosityZeroCheck], prefix+verbosityZeroCheck, true, `When true, logcheck will check whether the parameter for V() is 0.`)
 	logcheckFlags.BoolVar(c.enabled[keyCheck], prefix+keyCheck, true, `When true, logcheck will check whether name arguments are valid keys according to the guidelines in (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments).`)
+	logcheckFlags.BoolVar(c.enabled[valueCheck], prefix+valueCheck, false, `When true, logcheck will check for problematic values (for example, types that have an incomplete fmt.Stringer implementation).`)
 	logcheckFlags.BoolVar(c.enabled[deprecationsCheck], prefix+deprecationsCheck, true, `When true, logcheck will analyze the usage of deprecated Klog function calls.`)
 	logcheckFlags.Var(&c.fileOverrides, "config", `A file which overrides the global settings for checks on a per-file basis via regular expressions.`)
 
@@ -145,6 +148,7 @@ func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass, c *config) {
 		fName := selExpr.Sel.Name
 
 		filename := pass.Pkg.Path() + "/" + path.Base(pass.Fset.Position(fexpr.Pos()).Filename)
+		valueCheckEnabled := c.isEnabled(valueCheck, filename)
 		keyCheckEnabled := c.isEnabled(keyCheck, filename)
 		parametersCheckEnabled := c.isEnabled(parametersCheck, filename)
 
@@ -178,7 +182,7 @@ func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass, c *config) {
 				return
 			}
 
-			if keyCheckEnabled || parametersCheckEnabled {
+			if keyCheckEnabled || parametersCheckEnabled || valueCheckEnabled {
 				// if format specifier is used, check for arg length will most probably fail
 				// so check for format specifier first and skip if found
 				if parametersCheckEnabled && checkForFormatSpecifier(fexpr, pass) {
@@ -186,9 +190,9 @@ func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass, c *config) {
 				}
 				switch fName {
 				case "InfoS":
-					kvCheck(args[1:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled)
+					kvCheck(args[1:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled)
 				case "ErrorS":
-					kvCheck(args[2:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled)
+					kvCheck(args[2:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled)
 				}
 			}
 			// verbosity Zero Check
@@ -196,7 +200,7 @@ func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass, c *config) {
 				checkForVerbosityZero(fexpr, pass)
 			}
 		} else if isGoLogger(selExpr.X, pass) {
-			if keyCheckEnabled || parametersCheckEnabled {
+			if keyCheckEnabled || parametersCheckEnabled || valueCheckEnabled {
 				// if format specifier is used, check for arg length will most probably fail
 				// so check for format specifier first and skip if found
 				if parametersCheckEnabled && checkForFormatSpecifier(fexpr, pass) {
@@ -204,11 +208,11 @@ func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass, c *config) {
 				}
 				switch fName {
 				case "WithValues":
-					kvCheck(args, fun, pass, fName, keyCheckEnabled, parametersCheckEnabled)
+					kvCheck(args, fun, pass, fName, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled)
 				case "Info":
-					kvCheck(args[1:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled)
+					kvCheck(args[1:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled)
 				case "Error":
-					kvCheck(args[2:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled)
+					kvCheck(args[2:], fun, pass, fName, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled)
 				}
 			}
 			if c.isEnabled(withHelpersCheck, filename) {
@@ -551,7 +555,7 @@ func isVerbosityZero(expr ast.Expr) bool {
 
 // kvCheck check if all keys in keyAndValues are valid keys according to the guidelines
 // and that the values can be formatted.
-func kvCheck(keyValues []ast.Expr, fun ast.Expr, pass *analysis.Pass, funName string, keyCheckEnabled, parametersCheckEnabled bool) {
+func kvCheck(keyValues []ast.Expr, fun ast.Expr, pass *analysis.Pass, funName string, keyCheckEnabled, parametersCheckEnabled, valueCheckEnabled bool) {
 	if len(keyValues)%2 != 0 {
 		pass.Report(analysis.Diagnostic{
 			Pos:     fun.Pos(),
@@ -561,51 +565,120 @@ func kvCheck(keyValues []ast.Expr, fun ast.Expr, pass *analysis.Pass, funName st
 	}
 
 	for index, arg := range keyValues {
-		if index%2 != 0 {
-			continue
+		switch index % 2 {
+		case 0:
+			// Key in key/value pair.
+			checkKey(arg, pass, keyCheckEnabled, parametersCheckEnabled)
+		case 1:
+			// Value in key/value pair.
+			checkValue(arg, pass, valueCheckEnabled)
 		}
+	}
+}
 
-		// Check keys?
-		if !keyCheckEnabled && !parametersCheckEnabled {
-			continue
-		}
-		lit, ok := arg.(*ast.BasicLit)
-		if !ok {
+// checkKey checks the key in a key/value pair.
+func checkKey(arg ast.Expr, pass *analysis.Pass, keyCheckEnabled, parametersCheckEnabled bool) {
+	if !keyCheckEnabled && !parametersCheckEnabled {
+		return
+	}
+
+	lit, ok := arg.(*ast.BasicLit)
+	if !ok {
+		pass.Report(analysis.Diagnostic{
+			Pos:     arg.Pos(),
+			Message: fmt.Sprintf("Key positional arguments are expected to be inlined constant strings. Please replace %v provided with string value.", arg),
+		})
+		return
+	}
+
+	if lit.Kind != token.STRING {
+		pass.Report(analysis.Diagnostic{
+			Pos:     arg.Pos(),
+			Message: fmt.Sprintf("Key positional arguments are expected to be inlined constant strings. Please replace %v provided with string value.", lit.Value),
+		})
+		return
+	}
+
+	switch {
+	case parametersCheckEnabled:
+		// This is the less strict check.
+		isASCII := utf8string.NewString(lit.Value).IsASCII()
+		if !isASCII {
 			pass.Report(analysis.Diagnostic{
-				Pos:     fun.Pos(),
-				Message: fmt.Sprintf("Key positional arguments are expected to be inlined constant strings. Please replace %v provided with string value.", arg),
+				Pos:     arg.Pos(),
+				Message: fmt.Sprintf("Key positional arguments %s are expected to be lowerCamelCase alphanumeric strings. Please remove any non-Latin characters.", lit.Value),
 			})
-			continue
 		}
-		if lit.Kind != token.STRING {
+	case keyCheckEnabled:
+		// This is the stricter check.
+		keyMatchRe := regexp.MustCompile(`(^[A-Z]{2,}|^[a-z])[[:alnum:]]*$`)
+		match := keyMatchRe.Match([]byte(strings.Trim(lit.Value, "\"")))
+		if !match {
 			pass.Report(analysis.Diagnostic{
-				Pos:     fun.Pos(),
-				Message: fmt.Sprintf("Key positional arguments are expected to be inlined constant strings. Please replace %v provided with string value.", lit.Value),
+				Pos:     arg.Pos(),
+				Message: fmt.Sprintf("Key positional arguments %s are expected to be alphanumeric and start with either one lowercase or two uppercase letters. Please refer to https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments.", lit.Value),
 			})
-			continue
 		}
-		switch {
-		case parametersCheckEnabled:
-			// This is the less strict check.
-			isASCII := utf8string.NewString(lit.Value).IsASCII()
-			if !isASCII {
+	}
+}
+
+// checkValue checks the value in a key/value pair.
+func checkValue(arg ast.Expr, pass *analysis.Pass, valueCheckEnabled bool) {
+	if !valueCheckEnabled {
+		return
+	}
+
+	// Check the type.
+	if typeAndValue, ok := pass.TypesInfo.Types[arg]; ok {
+		if obj, index, _ := types.LookupFieldOrMethod(typeAndValue.Type, typeAndValue.Addressable(), nil /* package */, "String"); obj != nil {
+			if function, ok := obj.(*types.Func); ok && isFmtString(function) && len(index) > 1 && !isWrapperStruct(typeAndValue.Type) {
 				pass.Report(analysis.Diagnostic{
-					Pos:     fun.Pos(),
-					Message: fmt.Sprintf("Key positional arguments %s are expected to be lowerCamelCase alphanumeric strings. Please remove any non-Latin characters.", lit.Value),
+					Pos:     arg.Pos(),
+					Message: fmt.Sprintf("The type %s inherits %s as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO.", typeAndValue.Type.String(), function.FullName()), // TODO: https://github.com/kubernetes/kubernetes/pull/116952
 				})
-				continue
-			}
-		case keyCheckEnabled:
-			// This is the stricter check.
-			keyMatchRe := regexp.MustCompile(`(^[A-Z]{2,}|^[a-z])[[:alnum:]]*$`)
-			match := keyMatchRe.Match([]byte(strings.Trim(lit.Value, "\"")))
-			if !match {
-				pass.Report(analysis.Diagnostic{
-					Pos:     fun.Pos(),
-					Message: fmt.Sprintf("Key positional arguments %s are expected to be alphanumeric and start with either one lowercase or two uppercase letters. Please refer to https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments.", lit.Value),
-				})
-				continue
 			}
 		}
 	}
+}
+
+// isFmtString checks whether the function has the "func() string" signature.
+func isFmtString(function *types.Func) bool {
+	signature, ok := function.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	params := signature.Params()
+	if params != nil && params.Len() != 0 {
+		return false
+	}
+	results := signature.Results()
+	if results == nil || results.Len() != 1 {
+		return false
+	}
+	result := results.At(0)
+	basic, ok := result.Type().(*types.Basic)
+	if !ok {
+		return false
+	}
+	if basic.Kind() != types.String {
+		return false
+	}
+	return true
+}
+
+// isWrapperStruct returns true for types that are a struct with a single field
+// or a pointer to one, like for example
+// https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time.
+func isWrapperStruct(t types.Type) bool {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	if named, ok := t.(*types.Named); ok {
+		t = named.Underlying()
+	}
+	if strct, ok := t.(*types.Struct); ok {
+		return strct.NumFields() == 1
+	}
+
+	return false
 }

--- a/logcheck/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/logcheck/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TypeMeta struct {
+	Kind       string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
+}
+
+// String is generated (https://github.com/kubernetes/apimachinery/blob/v0.26.3/pkg/apis/meta/v1/generated.pb.go#L4757).
+func (this *TypeMeta) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&TypeMeta{`,
+		`Kind:` + fmt.Sprintf("%v", this.Kind) + `,`,
+		`APIVersion:` + fmt.Sprintf("%v", this.APIVersion) + `,`,
+		`}`,
+	}, "")
+	return s
+}

--- a/logcheck/testdata/src/stringer/stringer.go
+++ b/logcheck/testdata/src/stringer/stringer.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stringer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klog "k8s.io/klog/v2"
+)
+
+func foo() {
+	klog.Background().Info("Starting", "config", config{})
+	klog.Background().Info("Starting", "config", configWithStringer{})
+	klog.Background().Info("Starting", "config", &config{}) // want `The type \*stringer.config inherits \(\*k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta\).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String\(\) for the type or wrap it with TODO.`
+	klog.Background().Info("Starting", "config", &configWithStringer{})
+	klog.Background().Info("Starting", "config", &simpleConfig{})
+}
+
+// config mimicks KubeletConfig (see
+// https://github.com/kubernetes/kubernetes/pull/115950).  As far as logging is
+// concerned, the type is broken: it implements fmt.Stringer because it
+// embeds TypeMeta, but the result of String() is incomplete.
+type config struct {
+	metav1.TypeMeta // implements fmt.Stringer (but only for addressable values)
+
+	RealField int
+}
+
+type configWithStringer config
+
+func (c configWithStringer) Size() int {
+	return 1
+}
+
+func (c configWithStringer) String() string {
+	return "foo"
+}
+
+// simpleConfig only has a single field. In this case inheriting the String implementation
+// is fine. This occurs for https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time.
+type simpleConfig struct {
+	metav1.TypeMeta
+}


### PR DESCRIPTION
This is a static analysis check for the problem reported in https://github.com/kubernetes/kubernetes/pull/115950: converting unstructured logging of the form `"%v", someObj` to `"obj", someObj` produces undesirable output in the klog text format when `someObj` is of a type which has an incomplete `fmt.Stringer` implementation because it inherits that from an embedded field.

In Kubernetes, this currently finds:
```
cmd/kubelet/app/server.go:259:61: The type *k8s.io/kubernetes/pkg/kubelet/apis/config.KubeletConfiguration inherits (*k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
			                                                         ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:206:61: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
				logger.V(5).Info("Volume detached--skipping", "volume", attachedVolume)
				                                                        ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:235:84: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
				logger.V(5).Info("Cannot detach volume because it is still mounted", "volume", attachedVolume)
				                                                                               ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:255:113: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
				logger.Error(err, "UpdateNodeStatusForNode failed while attempting to report volume as attached", "volume", attachedVolume)
				                                                                                                            ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:265:73: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
			logger.V(5).Info("Starting attacherDetacher.DetachVolume", "volume", attachedVolume)
			                                                                     ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:273:69: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
					logger.Info("attacherDetacher.DetachVolume started", "volume", attachedVolume)
					                                                               ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:276:202: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
					logger.Info("attacherDetacher.DetachVolume started: this volume is not safe to detach, but maxWaitForUnmountDuration expired, force detaching", "duration", rc.maxWaitForUnmountDuration, "volume", attachedVolume)
					                                                                                                                                                                                                    ^
pkg/controller/volume/attachdetach/reconciler/reconciler.go:288:83: The type k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache.AttachedVolume inherits (*k8s.io/kubernetes/pkg/volume/util/operationexecutor.AttachedVolume).String as implementation of fmt.Stringer, which covers only a subset of the value. Implement String() for the type or wrap it with TODO. (logcheck)
					logger.Error(err, "attacherDetacher.DetachVolume failed to start", "volume", attachedVolume)
					                                                                             ^
```