### PR TITLE
logcheck: allow klog.Format for contextual logging

### DIFF
--- a/logcheck/pkg/logcheck.go
+++ b/logcheck/pkg/logcheck.go
@@ -370,6 +370,7 @@ func isContextualCall(fName string) bool {
 		"EnableContextualLogging",
 		"FlushAndExit",
 		"FlushLogger",
+		"Format",
 		"FromContext",
 		"InitFlags",
 		"KObj",


### PR DESCRIPTION
The new API call is useful also for contextual logging and thus allowed.