### PR TITLE
logcheck: Exclude key value checking for variadic input

### DIFF
--- a/logcheck/testdata/src/gologr/gologr.go
+++ b/logcheck/testdata/src/gologr/gologr.go
@@ -35,4 +35,12 @@ func logging() {
 	logger.V(1).Info("hello", "missing value") // want `Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.`
 	logger.V(1).Error(nil, "hello", 1, 2)      // want `Key positional arguments are expected to be inlined constant strings. Please replace 1 provided with string value`
 	logger.V(1).WithValues("missing value")    // want `Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.`
+
+	// variadic input to logger.Info, logger.Error, logger.WithValues functions
+	kvs := []interface{}{"key1", "value1"}
+	logger.Info("foo message", kvs...)
+	logger.Error(nil, "foo error message", kvs...)
+	logger.WithValues(kvs...)
+	logger.WithValues(kvs)                      // want `Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.`
+	logger.Error(nil, "foo error message", kvs) // want `Additional arguments to Error should always be Key Value pairs. Please check if there is any key or value missing.`
 }

--- a/logcheck/testdata/src/parameters/parameters.go
+++ b/logcheck/testdata/src/parameters/parameters.go
@@ -21,6 +21,7 @@ limitations under the License.
 package parameters
 
 import (
+	"context"
 	"fmt"
 
 	klog "k8s.io/klog/v2"
@@ -52,4 +53,15 @@ func parameterCalls() {
 	klog.InfoS("hello", 1, 2) // want `Key positional arguments are expected to be inlined constant strings. Please replace 1 provided with string value`
 	klog.ErrorS(nil, "hello", "1", 2)
 	klog.ErrorS(nil, "hello", 1, 2) // want `Key positional arguments are expected to be inlined constant strings. Please replace 1 provided with string value`
+
+	// variadic input to klog.Info*, klog.Error*, klog.LoggerWithValues functions
+	kvs := []interface{}{"key1", "value1"}
+	klog.InfoS("foo message", kvs) // want `Additional arguments to InfoS should always be Key Value pairs. Please check if there is any key or value missing.`
+	klog.ErrorS(nil, "foo error message", kvs...)
+	klog.Info(kvs...)
+	klog.Error(kvs...)
+
+	logger := klog.FromContext(context.Background())
+	klog.LoggerWithValues(logger, kvs...)
+	klog.LoggerWithValues(logger, kvs) // want `Additional arguments to LoggerWithValues should always be Key Value pairs. Please check if there is any key or value missing.`
 }


### PR DESCRIPTION
Exclude key-value pairs checking for variadic arguments to following functions -
- klog.Error, klog.ErrorS
- klog.Info, klog.InfoS,
- klog.LoggerWithValues
- logr.Logger.Error
- logr.Logger.Info
- logr.Logger.WithValues

Reference: https://github.com/kubernetes-sigs/logtools/issues/19 