### PR TITLE
Add SafePtr to contextual logging allow list functions

### DIFF
--- a/logcheck/pkg/logcheck.go
+++ b/logcheck/pkg/logcheck.go
@@ -422,6 +422,7 @@ func isContextualCall(fName string) bool {
 		"LoggerWithName",
 		"LoggerWithValues",
 		"NewContext",
+		"SafePtr",
 		"SetLogger",
 		"SetLoggerWithOptions",
 		"StartFlushDaemon",


### PR DESCRIPTION
This PR adds `klog.SafePtr` to the list of the functions allowed after the migration to contextual logging. We use this function to prevent panics when logging nil pointers.

Reference: https://github.com/kubernetes/kubernetes/pull/121554