### PR TITLE
bump dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,7 @@ jobs:
         go-versions:
         - "1.20"
         - "1.21"
+        - "1.22"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         go-versions:
-        - "1.20"
-        - "1.21"
         - "1.22"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.22'
         cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.2
+        version: v1.58.1
+

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module sigs.k8s.io/logtools
 go 1.20
 
 require (
-	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
-	golang.org/x/tools v0.16.1
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
+	golang.org/x/tools v0.21.0
 )
 
-require golang.org/x/mod v0.14.0 // indirect
+require (
+	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/logtools
 
-go 1.20
+go 1.22
 
 require (
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
-golang.org/x/exp v0.0.0-20230807204917-050eac23e9de h1:l5Za6utMv/HsBWWqzt4S8X17j+kt1uVETUX5UFhn2rE=
-golang.org/x/exp v0.0.0-20230807204917-050eac23e9de/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
-golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
-golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
+golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=


### PR DESCRIPTION
go: upgraded golang.org/x/exp v0.0.0-20230807204917-050eac23e9de => v0.0.0-20240506185415-9bf2ced13842
go: upgraded golang.org/x/mod v0.14.0 => v0.17.0
go: upgraded golang.org/x/sync v0.5.0 => v0.7.0
go: upgraded golang.org/x/tools v0.16.1 => v0.21.0

This fixes (at least for me) a crash when checking csi-lib-utils when using Kubernetes 1.30 there

Fixes: https://github.com/kubernetes-sigs/logtools/issues/28

It also bumps the Go version in go.mod to 1.22.2. This turned out be necessary because of https://github.com/golang/go/issues/67282.

It is unclear whether building logtools with Go < 1.22 still works. The GitHub actions failed to install older Go without any error message.

cc @jsafrane @bells17 

