### PR TITLE
Added wrapper for golangci-lint's module plugin system wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/logtools
 go 1.22
 
 require (
+	github.com/golangci/plugin-module-register v0.1.1
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/tools v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
+github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=

--- a/logcheck/gclplugin/plugin.go
+++ b/logcheck/gclplugin/plugin.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package gclplugin implements the golangci-lint's module plugin interface for logcheck to be used
+// as a private linter in golangci-lint. See more details at
+// https://golangci-lint.run/plugins/module-plugins/.
+package gclplugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+	"sigs.k8s.io/logtools/logcheck/pkg"
+)
+
+func init() {
+	register.Plugin("logcheck", New)
+}
+
+type settings struct {
+	Check  map[string]bool `json:"check"`
+	Config string          `json:"config"`
+}
+
+// New Module Plugin System, see https://golangci-lint.run/plugins/module-plugins/.
+func New(pluginSettings interface{}) (register.LinterPlugin, error) {
+	// We could manually parse the settings. This would involve several
+	// type assertions. Encoding as JSON and then decoding into our
+	// settings struct is easier.
+	//
+	// The downside is that format errors are less user-friendly.
+	var buffer bytes.Buffer
+	if err := json.NewEncoder(&buffer).Encode(pluginSettings); err != nil {
+		return nil, fmt.Errorf("encoding settings as internal JSON buffer: %v", err)
+	}
+	var s settings
+	decoder := json.NewDecoder(&buffer)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&s); err != nil {
+		return nil, fmt.Errorf("decoding settings from internal JSON buffer: %v", err)
+	}
+
+	return &LogcheckPlugin{settings: s}, nil
+}
+
+var _ register.LinterPlugin = (*LogcheckPlugin)(nil)
+
+type LogcheckPlugin struct {
+	settings settings
+}
+
+// BuildAnalyzers implements register.LinterPlugin.
+func (l *LogcheckPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	// Now create an analyzer and configure it.
+	analyzer, config := pkg.Analyser()
+
+	for check, enabled := range l.settings.Check {
+		if err := config.SetEnabled(check, enabled); err != nil {
+			// No need to wrap, the error is informative.
+			return nil, err
+		}
+	}
+
+	if err := config.ParseConfig(l.settings.Config); err != nil {
+		return nil, fmt.Errorf("parsing config: %v", err)
+	}
+
+	return []*analysis.Analyzer{analyzer}, nil
+}
+
+// GetLoadMode implements register.LinterPlugin.
+func (l *LogcheckPlugin) GetLoadMode() string { return register.LoadModeSyntax }


### PR DESCRIPTION
golangci-lint introduced a [Module Plugin System](https://golangci-lint.run/plugins/module-plugins/), which enables one to compile a custom golangci-lint binary with plugins baked-in.

This PR adds the necessary wrapper so that one can create a custom binary with logcheck baked in using the following configs:

<details>
<summary>.custom-gcl.yml</summary>

```yaml

version: v1.59.1
plugins:
    - module: "sigs.k8s.io/logtools"
      import: "sigs.k8s.io/logtools/logcheck/gclplugin"
      version: latest # or whichever version would contain this PRs code
```
</details>

<details>
<summary>.golangci.yaml</summary>

```yaml

linters:
  disable-all: true
  enable:
    - logcheck

linters-settings:
  custom:
    logcheck:
      type: "module"
      description: structured logging checker
      original-url: sigs.k8s.io/logtools/logcheck
      settings:
        check:
          contextual: true
        config: |
          structured .*
          contextual .*

```
</details>

---

To test out the changes before merging, I've also created a fork with the module name changed so that one can create a custom golangci-lint binary using the following file:

<details>
<summary>.custom-gcl.yml</summary>

```yaml

version: v1.59.1
plugins:
  - module: "github.com/ThomasK33/logtools"
    import: "github.com/ThomasK33/logtools/logcheck/gclplugin"
    version: v0.0.0-20240709111712-db940b18785d
```
</details>

And then run a `golangci-lint custom`, followed by a `./custom-gcl run`.