### PR TITLE
logcheck: detect logger.V().Error

### DIFF
--- a/logcheck/README.md
+++ b/logcheck/README.md
@@ -105,6 +105,20 @@ runtime in klog.
 
 This check flags all invocation of `klog.V(0)` or any of it's equivalent as errors
 
+## verbosity-error (enabled by default)
+
+`logger.V(5).Error` for a `logr.Logger` instance is identical to `logger.Error`
+because `logger.V(5)` is just another `Logger` instance and `Error` bypasses
+all verbosity checks. This is different from `klog.V(5).ErrorS`, which does
+the verbosity check.
+
+If the call really is an `Error` log call, i.e. with "an admin must know about
+this" importance, then the preceding `V()` should be removed. If the semantic
+from klog is desired, then the corresponding go-logr call is
+`logger.V(5).Info`, with the error passed in a `"err", error` key/value
+pair - at least in Kubernetes. Other projects may have different naming
+conventions.
+
 ## key (enabled by default)
 
 This check flags check whether name arguments are valid keys according to the

--- a/logcheck/main_test.go
+++ b/logcheck/main_test.go
@@ -112,17 +112,19 @@ func TestAnalyzer(t *testing.T) {
 		{
 			name: "Do not allow Verbosity Zero logs",
 			enabled: map[string]string{
-				"structured": "false",
-				"key":        "false",
+				"structured":      "false",
+				"key":             "false",
+				"verbosity-error": "false",
 			},
 			testPackage: "doNotAllowVerbosityZeroLogs",
 		},
 		{
 			name: "Allow Verbosity Zero logs",
 			enabled: map[string]string{
-				"structured":     "false",
-				"verbosity-zero": "false",
-				"key":            "false",
+				"structured":      "false",
+				"verbosity-zero":  "false",
+				"verbosity-error": "false",
+				"key":             "false",
 			},
 			testPackage: "allowVerbosityZeroLogs",
 		},

--- a/logcheck/testdata/src/gologr/gologr.go
+++ b/logcheck/testdata/src/gologr/gologr.go
@@ -33,7 +33,7 @@ func logging() {
 	logger.WithValues("missing value")    // want `Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.`
 
 	logger.V(1).Info("hello", "missing value") // want `Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.`
-	logger.V(1).Error(nil, "hello", 1, 2)      // want `Key positional arguments are expected to be inlined constant strings. Please replace 1 provided with string value`
+	logger.V(1).Error(nil, "hello", 1, 2)      // want `Key positional arguments are expected to be inlined constant strings. Please replace 1 provided with string value` `V\(\).Error ignores the verbosity and always logs. Use only Error if that is desired, otherwise V\(\).Info\(..., "err", err\).`
 	logger.V(1).WithValues("missing value")    // want `Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.`
 
 	// variadic input to logger.Info, logger.Error, logger.WithValues functions
@@ -43,4 +43,5 @@ func logging() {
 	logger.WithValues(kvs...)
 	logger.WithValues(kvs)                      // want `Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.`
 	logger.Error(nil, "foo error message", kvs) // want `Additional arguments to Error should always be Key Value pairs. Please check if there is any key or value missing.`
+
 }


### PR DESCRIPTION
This might be the result of a literal `klog.V().ErrorS` migration. But the semantic is different, which is worth calling out in the linter because it's not a compile error.